### PR TITLE
Export AWS_DEFAULT_REGION

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ EOF
 }
 ```
 
+The current region is exported as `AWS_DEFAULT_REGION` and you can use awscli without a region option.
+
 ### Open SSH port
 
 You can open the SSH port to the NAT instance.

--- a/data/init.sh
+++ b/data/init.sh
@@ -1,9 +1,11 @@
 #!/bin/bash -x
 
+# Determine the region
+export AWS_DEFAULT_REGION="$(/opt/aws/bin/ec2-metadata -z | sed 's/placement: \(.*\).$/\1/')"
+
 # Attach the ENI
-region="$(/opt/aws/bin/ec2-metadata -z | sed 's/placement: \(.*\).$/\1/')"
 instance_id="$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)"
-aws --region "$region" ec2 attach-network-interface \
+aws ec2 attach-network-interface \
     --instance-id "$instance_id" \
     --device-index 1 \
     --network-interface-id "${eni_id}"


### PR DESCRIPTION
This adds an export of `AWS_DEFAULT_REGION` to the shell to call awscli without a region option.