### PR TITLE
Add boolean variable use_spot_instance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ This is an open source software. Feel free to open issues and pull requests.
 |------|-------------|:----:|:-----:|:-----:|
 | extra\_user\_data | Extra script to run in the NAT instance | string | `""` | no |
 | image\_id | AMI of the NAT instance. Default to the latest Amazon Linux 2 | string | `""` | no |
-| instance\_types | Candidates of spot instance type for the NAT instance. This is used in the mixed instances policy | list | `[ "t3.nano", "t3a.nano" ]` | no |
+| instance\_types | Candidates of instance type for the NAT instance. This is used in the mixed instances policy | list | `[ "t3.nano", "t3a.nano" ]` | no |
+| use_spot_instance | Whether to use spot or on-demand EC2 instance | boolean | true | no |
 | key\_name | Name of the key pair for the NAT instance. You can set this to assign the key pair to the NAT instance | string | `""` | no |
 | name | Name for all the resources as identifier | string | n/a | yes |
 | private\_route\_table\_ids | List of ID of the route tables for the private subnets. You can set this to assign the each default route to the NAT instance | list | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,7 @@ resource "aws_autoscaling_group" "this" {
 
   mixed_instances_policy {
     instances_distribution {
+      on_demand_base_capacity                  = var.use_spot_instance ? 0 : 1
       on_demand_percentage_above_base_capacity = var.use_spot_instance ? 0 : 100
     }
     launch_template {

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "aws_autoscaling_group" "this" {
 
   mixed_instances_policy {
     instances_distribution {
-      on_demand_percentage_above_base_capacity = 0
+      on_demand_percentage_above_base_capacity = var.use_spot_instance ? 0 : 100
     }
     launch_template {
       launch_template_specification {

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,11 @@ variable "instance_types" {
   default     = ["t3.nano", "t3a.nano"]
 }
 
+variable "use_spot_instance" {
+  description = "Whether to use spot or on-demand EC2 instance"
+  default     = true
+}
+
 variable "key_name" {
   description = "Name of the key pair for the NAT instance. You can set this to assign the key pair to the NAT instance"
   default     = ""


### PR DESCRIPTION
This PR is to add a boolean variable `use_spot_instance`, so user can decide whether to use a spot or a normal on-demand EC2 for NAT.

Example
```
module "network-nat-instance" {
  source = "int128/nat-instance/aws"

  name                        = "nat-instance"
  vpc_id                      = module.network.vpc_id
  public_subnet               = module.network.public_subnets[0]
  private_subnets_cidr_blocks = module.network.private_subnets_cidr_blocks
  private_route_table_ids     = module.network.private_route_table_ids
  use_spot_instance           = false
}
```