### PR TITLE
fix issue: #16, tag ordering

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,12 +99,11 @@ resource "aws_launch_template" "this" {
 }
 
 resource "aws_autoscaling_group" "this" {
-  name_prefix      = var.name
-  desired_capacity = var.enabled ? 1 : 0
-  min_size         = var.enabled ? 1 : 0
-  max_size         = 1
-  vpc_zone_identifier = [
-  var.public_subnet]
+  name_prefix         = var.name
+  desired_capacity    = var.enabled ? 1 : 0
+  min_size            = var.enabled ? 1 : 0
+  max_size            = 1
+  vpc_zone_identifier = [var.public_subnet]
 
   mixed_instances_policy {
     instances_distribution {
@@ -125,9 +124,7 @@ resource "aws_autoscaling_group" "this" {
     }
   }
 
-
   // Generate asg tags from default tag list
-
   dynamic "tag" {
     for_each = var.tags
     content {
@@ -143,7 +140,6 @@ resource "aws_autoscaling_group" "this" {
     value               = "nat-instance-${var.name}"
     propagate_at_launch = true
   }
-
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -99,11 +99,12 @@ resource "aws_launch_template" "this" {
 }
 
 resource "aws_autoscaling_group" "this" {
-  name_prefix         = var.name
-  desired_capacity    = var.enabled ? 1 : 0
-  min_size            = var.enabled ? 1 : 0
-  max_size            = 1
-  vpc_zone_identifier = [var.public_subnet]
+  name_prefix      = var.name
+  desired_capacity = var.enabled ? 1 : 0
+  min_size         = var.enabled ? 1 : 0
+  max_size         = 1
+  vpc_zone_identifier = [
+  var.public_subnet]
 
   mixed_instances_policy {
     instances_distribution {
@@ -124,7 +125,25 @@ resource "aws_autoscaling_group" "this" {
     }
   }
 
-  tags = local.asg_tags
+
+  // Generate asg tags from default tag list
+
+  dynamic "tag" {
+    for_each = var.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
+  // Tag for name
+  tag {
+    key                 = "Name"
+    value               = "nat-instance-${var.name}"
+    propagate_at_launch = true
+  }
+
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -72,20 +72,4 @@ locals {
     var.tags, {
       Name = "nat-instance-${var.name}"
   })
-
-  // Generate asg tags by merging variables in object format
-  asg_tags = concat([
-    for key, value in var.tags : {
-      key                 = key
-      value               = value
-      propagate_at_launch = true
-    }
-    ], [
-    {
-      key                 = "Name"
-      value               = "nat-instance-${var.name}"
-      propagate_at_launch = true
-    }
-    ]
-  )
 }


### PR DESCRIPTION
This fixes tag ordering by using the "tag" attribute rather than "tags" in the autoscaling group. 