### PR TITLE
Add var to handle eip outside of module

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ No requirements.
 | user\_data\_runcmd | Additional runcmd section of cloud-init | `list` | `[]` | no |
 | user\_data\_write\_files | Additional write\_files section of cloud-init | `list` | `[]` | no |
 | vpc\_id | ID of the VPC | `string` | n/a | yes |
+| eip_creation | Whether to create an eip | `bool` | `true` | no | 
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "aws_network_interface" "this" {
 }
 
 resource "aws_eip" "this" {
-  count             = var.enabled ? 1 : 0
+  count             = var.enabled ? var.eip_creation ? 1 : 0 : 0
   network_interface = aws_network_interface.this.id
   tags              = local.common_tags
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "eip_id" {
   description = "ID of the Elastic IP"
-  value       = var.enabled ? aws_eip.this[0].id : ""
+  value       = var.enabled ? var.eip_creation ? aws_eip.this[0].id : "" : ""
 }
 
 output "eip_public_ip" {
   description = "Public IP of the Elastic IP for the NAT instance"
-  value       = var.enabled ? aws_eip.this[0].public_ip : ""
+  value       = var.enabled ? var.eip_creation ? aws_eip.this[0].public_ip : "" : ""
 }
 
 output "eni_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,11 @@ variable "user_data_runcmd" {
   type        = list
   default     = []
 }
+variable "eip_creation" {
+  description = "Whether to create an elastic ip"
+  type        = bool
+  default     = true
+}
 
 locals {
   // Generate common tags by merging variables and default Name


### PR DESCRIPTION
Additional var introduced to stop creation of the modules eip instance. Eip can therefore be handled outside of the module for better switching between this module and nat gateway using one eip