### PR TITLE
Fix user-specified tags to take precedence

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -73,9 +73,12 @@ variable "user_data_runcmd" {
 }
 
 locals {
-  // Generate common tags by merging variables and default Name
+  // Merge the default tags and user-specified tags.
+  // User-specified tags take precedence over the default.
   common_tags = merge(
-    var.tags, {
+    {
       Name = "nat-instance-${var.name}"
-  })
+    },
+    var.tags,
+  )
 }


### PR DESCRIPTION
This will fix the user-specified tags to take precedence over the default tags.

See https://www.terraform.io/docs/configuration/functions/merge.html.