### PR TITLE
Prevent setting default route to eth0 after reboot

### DIFF
--- a/snat.sh
+++ b/snat.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -x
+#!/bin/bash
+set -x
 
 # wait for eth1
 while ! ip link show dev eth1; do
@@ -9,6 +10,9 @@ done
 sysctl -q -w net.ipv4.ip_forward=1
 sysctl -q -w net.ipv4.conf.eth1.send_redirects=0
 iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE
+
+# prevent setting the default route to eth0 after reboot
+rm -f /etc/sysconfig/network-scripts/ifcfg-eth0
 
 # switch the default route to eth1
 ip route del default dev eth0


### PR DESCRIPTION
This will resolve the issue of https://github.com/int128/terraform-aws-nat-instance/issues/35#issuecomment-1019412838.