### PR TITLE
Fix NAT not working 2022-07

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -194,7 +194,9 @@ resource "aws_iam_role_policy" "eni" {
         {
             "Effect": "Allow",
             "Action": [
-                "ec2:AttachNetworkInterface"
+                "ec2:AttachNetworkInterface",
+                "ec2:ModifyNetworkInterfaceAttribute",
+                "ec2:DescribeInstances"
             ],
             "Resource": "*"
         }

--- a/runonce.sh
+++ b/runonce.sh
@@ -1,11 +1,24 @@
 #!/bin/bash -x
 
+sudo yum install -y jq
+
+INSTANCE_ID="$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)"
+REGION="$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')"
+
 # attach the ENI
 aws ec2 attach-network-interface \
-  --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-  --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
+  --region "$REGION" \
+  --instance-id "$INSTANCE_ID" \
   --device-index 1 \
   --network-interface-id "${eni_id}"
+
+# Disable source/destination checks
+for i in $(aws ec2 describe-instances --region "$REGION" --filter '[{"Name": "instance-id", "Values": ["'$INSTANCE_ID'"]}]' | jq -r .Reservations[0].Instances[0].NetworkInterfaces[].NetworkInterfaceId); do
+  aws ec2 modify-network-interface-attribute \
+    --region "$REGION" \
+    --network-interface-id "$i" \
+    --no-source-dest-check
+done
 
 # start SNAT
 systemctl enable snat

--- a/snat.sh
+++ b/snat.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
 set -x
 
-# wait for eth1
+# Wait for eth1
 while ! ip link show dev eth1; do
   sleep 1
 done
 
-# enable IP forwarding and NAT
+# Enable IP forwarding
 sysctl -q -w net.ipv4.ip_forward=1
+
+# Disable ICMP redirects on eth1
 sysctl -q -w net.ipv4.conf.eth1.send_redirects=0
+
+# Configure NAT
 iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE
+
+# Disable reverse path protection
+for i in $(find /proc/sys/net/ipv4/conf/ -name rp_filter) ; do
+  echo 0 > $i;
+done
 
 # prevent setting the default route to eth0 after reboot
 rm -f /etc/sysconfig/network-scripts/ifcfg-eth0


### PR DESCRIPTION
At some point in the past, reverse path protection was enabled for Amazon Linux 2 AMIs, which causes the host to silently drop all NAT traffic.

My investigation of this issue also uncovered the requirement to disable source/destination checks on the ENIs attached to the NAT box.

This pull request adds patches to brute-force disable reverse path protection and brute-force enable source/destination checks.

This is probably overkill to actually fix the issues, but it works.