### PR TITLE
Added required versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
# Description
- Added terraform require versions.
- Occurred warning when using provider argument.
```
Warning: Reference to undefined provider

  on vpc.tf line 107, in module "nat_us_east_1":
 107:     aws = aws.virginia

There is no explicit declaration for local provider name "aws" in
module.nat_us_east_1, so Terraform is assuming you mean to pass a
configuration for "hashicorp/aws".

If you also control the child module, add a required_providers entry named
"aws" with the source address "hashicorp/aws".


