### PR TITLE
fix(add missing tags for instance profile)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -157,6 +157,8 @@ resource "aws_autoscaling_group" "this" {
 resource "aws_iam_instance_profile" "this" {
   name_prefix = var.name
   role        = aws_iam_role.this.name
+
+  tags = local.common_tags
 }
 
 resource "aws_iam_role" "this" {


### PR DESCRIPTION
The resource doesn't generate costs but [default_tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider) are used when configured.