### PR TITLE
Security/Compliance fix - require IMDSv2 on NAT instance (#48)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,11 @@ resource "aws_launch_template" "this" {
     arn = aws_iam_instance_profile.this.arn
   }
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
   network_interfaces {
     associate_public_ip_address = true
     security_groups             = [aws_security_group.this.id]


### PR DESCRIPTION
Follow security best practices by disabling IMDSv1 on the Launch Template.

This will help anyone using this module who is required to meet compliance and/or security requirements that flag this feature.

https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/
https://aquasecurity.github.io/tfsec/v1.8.0/checks/aws/autoscaling/enforce-http-token-imds/