### PR TITLE
Fix loop that can run infinitely in some cases

### DIFF
--- a/snat.sh
+++ b/snat.sh
@@ -2,9 +2,14 @@
 set -x
 
 # wait for eth1
-while ! ip link show dev eth1; do
+end_time=$((SECONDS + 180))
+while [ $SECONDS -lt $end_time ] && ! ip link show dev eth1; do
   sleep 1
 done
+
+if ! ip link show dev eth1; then
+  exit 1
+fi
 
 # enable IP forwarding and NAT
 sysctl -q -w net.ipv4.ip_forward=1


### PR DESCRIPTION
Inside the `runonce.sh` script there is the `aws ec2 attach-network-interface` command,
If it fails (in my case when the interface was not yet released after system check failure and instance termination) the script goes on and then `snat.sh` will run.

There the `while` loop will hand as eth1 will never be available due to the previous failure.

This fix will allow the control flow to continue and reach a user provided script which is given via the `user_data` variable of this module.