### PR TITLE
feat: add variable for egress protocol

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_security_group_rule" "egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 0
   to_port           = 65535
-  protocol          = "tcp"
+  protocol          = var.egress_protocol
 }
 
 resource "aws_security_group_rule" "ingress_any" {

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,16 @@ variable "user_data_runcmd" {
   default     = []
 }
 
+variable "egress_protocol" {
+  description = "Protocol allowed to egress out of the NAT instance"
+  type        = string
+  default     = "tcp"
+  validation {
+    condition     = var.egress_protocol == "tcp" || var.egress_protocol == "udp" || var.egress_protocol == "all"
+    error_message = "The egress_protocol must be one of 'tcp', 'udp' or 'all'."
+  }
+}
+
 locals {
   // Merge the default tags and user-specified tags.
   // User-specified tags take precedence over the default.


### PR DESCRIPTION
Adds the ability to set the protocol for egress out of the NAT instance. The main driver for this is something like Tailscale which requires the ability to open an outbound UDP connection to get direct connectivity to other nodes.

It might be worth changing this to only have options for "tcp" or "all". Can't imagine a "udp" only NAT but maybe someone will want that.